### PR TITLE
Update Docker config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,25 @@
 FROM vrodriguezf/jupyterlab-cuda:latest
 
-# PYTHON PACKAGES with pip
-RUN pip install nbdev
-RUN pip install umap-learn
-RUN pip install tensorflow
-RUN pip install keras
-# RUN pip install papermill
-RUN pip install seaborn
-RUN pip install plotly
-
-## Python packages that need to be upgraded
+# Install and update Python packages with pip
+RUN python3 -m pip install --upgrade pip
+RUN pip install nbdev umap-learn tensorflow keras seaborn plotly
 RUN pip install --upgrade wandb fastcore papermill
+RUN pip install hdbscan --no-cache-dir --no-binary :all:
 
-# Environmental variables for wandb
-ENV LC_ALL=C.UTF-8
-ENV LANG=C.UTF-8
-
-# Add non-root user (call this with the specific UID and GIO of the host, to share permissions)
+# Add non-root user (call this with the specific UID and GID of the host, to share permissions)
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 ARG USER=user
-
 RUN addgroup --gid $GROUP_ID $USER
 RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID $USER
+
 
 # Copy the default jupyterlab settings user settings to the new user folder
 RUN cp -r /.jupyter /home/$USER/.jupyter
 RUN chown -R $USER_ID:$GROUP_ID /home/$USER/.jupyter
 
+
 # Create non root user home folder
 WORKDIR /home/$USER
-# setup share data folder before switching to user
-#RUN mkdir /home/$USER/data
-#RUN mkdir /home/$USER/data/PACMEL-2019
-#RUN chown -R $USER:$USER /home/$USER/data
+
 USER $USER

--- a/Dockerfile-rstudio
+++ b/Dockerfile-rstudio
@@ -1,20 +1,23 @@
 FROM vrodriguezf/rstudio-server-shiny-development:backup
 
+RUN apt-get update
+RUN apt-get install -y python3-pip
+RUN python3 -m pip install --upgrade pip
+RUN apt-get install -y python3-venv libxt-dev
 
-## Install reticulate, miniconda and Python packages
+
+## Install reticulate and create virtual environment using default Ubuntu installed Python
 
 RUN R -e "install.packages('reticulate')"
 
-ARG RETICULATE_MINICONDA_PATH=/usr/local/share/r-miniconda
-ARG RETICULATE_PYTHON_ENV=${RETICULATE_MINICONDA_PATH}/envs/r-reticulate
-ARG RETICULATE_PYTHON=${RETICULATE_PYTHON_ENV}/bin/python
+ARG RETICULATE_PYTHON_ENV=/usr/virtualenvs/venv_shiny_app
+ARG RETICULATE_PYTHON=${RETICULATE_PYTHON_ENV}/bin/python/
 
-RUN R -e "reticulate::install_miniconda(path = '${RETICULATE_MINICONDA_PATH}')"
-RUN echo "RETICULATE_MINICONDA_PATH=${RETICULATE_MINICONDA_PATH}" >> /${R_HOME}/etc/Renviron.site
+RUN R -e "reticulate::virtualenv_create(envname='${RETICULATE_PYTHON_ENV}', python='/usr/bin/python3')"
+RUN R -e "reticulate::virtualenv_install(c('numpy', 'pandas', 'wandb', 'hdbscan'), envname='${RETICULATE_PYTHON_ENV}')"
+
 RUN echo "RETICULATE_PYTHON_ENV=${RETICULATE_PYTHON_ENV}" >> /${R_HOME}/etc/Renviron.site
 RUN echo "RETICULATE_PYTHON=${RETICULATE_PYTHON}" >> /${R_HOME}/etc/Renviron.site
-
-RUN R -e "reticulate::py_install(c('pandas','wandb','hdbscan'), pip = TRUE, pip_options=c('--upgrade'))"
 
 
 ## Install R packages

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       args:
         - USER_ID=${USER_ID} #* 
         - GROUP_ID=${GROUP_ID} #* Important to define it to work with Pacmel Data hosted in UPM servers (This is the group id of the user in which the folder where pacmel data is shared is located) 
+        - USER=${USER_NAME} #*
     ports:
       - "${JUPYTER_PORT}:8888" #*
     expose:
@@ -14,9 +15,9 @@ services:
     environment:
       - WANDB_API_KEY=${WANDB_API_KEY} #*
     volumes:
-      - ./:/home/user/work
+      - ./:/home/${USER_NAME}/work #*
       - ~/.gitconfig:/etc/gitconfig # Need to create this file!
-      - ${LOCAL_DATA_PATH}:/home/user/data/PACMEL-2019 #*
+      - ${LOCAL_DATA_PATH}:/home/${USER_NAME}/data/PACMEL-2019 #*
   rstudio-server:
       build:
           context: ./


### PR DESCRIPTION
An update of the Docker config files (Dockerfile, Dockerfile-rstudio, docker-compose.yml) has been included to cover  the following objectives:

- Create a Python virtual environment using default Ubuntu installed Python (now 3.8) instead of the default miniconda version (now 3.6), to solve incompatibilities between JupyterLab and RStudio packages versions (several packages versions problems had been detected, the most recently with hdbscan, joblib and pickle).

- Install the hdbscan package in JupyterLab, using next pip options to avoid incompatibilities with numpy 1.19 (see scikit-learn-contrib/hdbscan#457): `RUN pip install hdbscan --no-cache-dir --no-binary :all:`

- Unify both containers structure, using /home/${USER_NAME} path [with the user name defined in the .env file] as home folder in both containers.

- Fix Issue #30, installing libxt-dev package in RStudio image.
